### PR TITLE
add timesync config

### DIFF
--- a/roles/setup/tasks/config.yml
+++ b/roles/setup/tasks/config.yml
@@ -1,0 +1,20 @@
+- name: Update timesyncd config (main NTP)
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^#NTP="
+    line: "NTP=time.google.com"
+  become: True
+
+- name: Update timesyncd config (fallback NTP)
+  lineinfile:
+    dest: /etc/ssh/sshd_config
+    regexp: "^#FallbackNTP"
+    line: "FallbackNTP=0.arch.pool.ntp.org 1.arch.pool.ntp.org 2.arch.pool.ntp.org 3.arch.pool.ntp.org"
+  become: True
+
+- name: Restart systemd-timesyncd
+  systemd:
+    state: restarted
+    daemon_reload: yes
+    name: systemd-timesyncd
+  become: True

--- a/roles/setup/tasks/main.yml
+++ b/roles/setup/tasks/main.yml
@@ -1,5 +1,6 @@
 # run setup tasks
 - import_tasks: auth.yml
+- import_tasks: config.yml
 - import_tasks: lib.yml
 - import_tasks: user-ansible.yml
 - import_tasks: user-amasuda.yml


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- by default timesync not works

## What
<!-- What features are added in this PR -->
- update timesync config

## QA, Evidence
<!-- Things that support this PR is correct -->

```

TASK [setup : Update timesyncd config (main NTP)] ******************************
ok: [nuc]

TASK [setup : Update timesyncd config (fallback NTP)] **************************
ok: [nuc]


$ less /etcd/systemd/timesyncd.conf


[Time]
NTP=time.google.com
FallbackNTP=0.arch.pool.ntp.org 1.arch.pool.ntp.org 2.arch.pool.ntp.org 3.arch.pool.ntp.org
#RootDistanceMaxSec=5
#PollIntervalMinSec=32
#PollIntervalMaxSec=2048
```


```
[root@archlinux ~]# date
Tue Nov 17 12:36:07 AM JST 2020
```
