### PR TITLE
change speedtest exporter scrape config

### DIFF
--- a/roles/kind/files/k8s/monitoring/prometheus.yaml
+++ b/roles/kind/files/k8s/monitoring/prometheus.yaml
@@ -97,9 +97,7 @@ data:
     - job_name: 'prometheus'
       static_configs:
       - targets: ['localhost:9090']
-    - job_name: 'node-exporter'
-      static_configs:
-      - targets: ['node-exporter.monitoring.svc.cluster.local:9100']
+    
     - job_name: 'kubernetes-nodes'
       scheme: https
       tls_config:
@@ -125,6 +123,7 @@ data:
       - source_labels: [__name__]
         action: drop
         regex: 'reflector_.+?'
+    
     # Scrape config for pods
     # The relabeling allows the actual pod scrape endpoint to be configured via the
     # following annotations:
@@ -172,11 +171,37 @@ data:
       - source_labels: [__meta_kubernetes_pod_node_name]
         action: replace
         target_label: instance
-      - source_labels: [kubernetes_pod_name]
+    
+    # Scrape config for speedtest exporter
+    # global scrape interval 1m is too short for speedtest exporter
+    - job_name: 'speedtest-exporter'
+      scrape_interval: 5m
+      scrape_timeout: 2m
+      tls_config:
+        insecure_skip_verify: true
+      kubernetes_sd_configs:
+      - role: pod
+      relabel_configs:
+      - source_labels: [component]
+        regex: (.*)
+        target_label: component
+        replacement: kubernetes
+      # keep label if pod name starts with speedtest-exporter
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: keep
+        regex: (speedtest-exporter.*)
+      - action: labelmap
+        regex: __meta_kubernetes_pod_label_(.+)
+      - source_labels: [__meta_kubernetes_namespace]
         action: replace
-        regex: pod-network-problem-detector-.+
-        replacement: ''
+        target_label: kubernetes_namespace
+      - source_labels: [__meta_kubernetes_pod_name]
+        action: replace
         target_label: kubernetes_pod_name
+      - source_labels: [__meta_kubernetes_pod_node_name]
+        action: replace
+        target_label: instance
+
     # Scrape config for service endpoints.
     #
     # The relabeling allows the actual service scrape endpoint to be configured
@@ -228,6 +253,7 @@ data:
       - source_labels: [__name__]
         action: drop
         regex: 'kube_pod_container_status_waiting_reason|kube_pod_container_status_terminated_reason'
+    
     # Scrape config for Kubernetes API Server
     - job_name: 'kubernetes-apiservers'
       scheme: https
@@ -248,6 +274,7 @@ data:
       - source_labels: [__meta_kubernetes_namespace, __meta_kubernetes_service_name, __meta_kubernetes_endpoint_port_name]
         action: keep
         regex: default;kubernetes;https
+    
     # Scrape config for Kubelet cAdvisor.
     # This is required for Kubernetes 1.7.3 and later, where cAdvisor metrics
     # (those whose names begin with 'container_') have been removed from the

--- a/roles/kind/files/k8s/monitoring/speedtest-exporter.yaml
+++ b/roles/kind/files/k8s/monitoring/speedtest-exporter.yaml
@@ -25,10 +25,11 @@ spec:
     metadata:
       labels:
         app: speedtest-exporter
-      annotations:
-        # annotations for sd in prometheus
-        prometheus.io/scrape: "true"
-        prometheus.io/port: "9112"
+      # comment annotation for changing scrape interval for speedtest
+      #annotations:
+      #  # annotations for sd in prometheus
+      #  prometheus.io/scrape: "true"
+      #  prometheus.io/port: "9112"
     spec:
       containers:
       - name: speedtest-exporter

--- a/roles/setup/tasks/user-amasuda.yml
+++ b/roles/setup/tasks/user-amasuda.yml
@@ -18,7 +18,7 @@
 - name: write private key from var
   copy:
     dest: /home/amasuda/.ssh/github/id_rsa
-    content: "{{github_private_key_amasuda}}"
+    content: "{{ github_private_key_amasuda }}"
     owner: amasuda
     group: wheel
     mode: "0400"
@@ -27,7 +27,7 @@
 - name: write public key from var
   copy:
     dest: /home/amasuda/.ssh/github/id_rsa_pub
-    content: "{{github_public_key_amasuda}}"
+    content: "{{ github_public_key_amasuda }}"
     owner: amasuda
     group: wheel
     mode: "0400"


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- global scrape config's interval is set to 1m with 30s timeout. This config is too short for speedtest exporter
- it could not get metrics if it's too short timeout

## What
<!-- What features are added in this PR -->
- change speedtest exporter scrape config

## QA, Evidence
<!-- Things that support this PR is correct -->
- applied PR setting and checked if it works with my environment

![image](https://user-images.githubusercontent.com/1454332/104832138-2a3dc600-58d2-11eb-97b4-ff0520ac1ffb.png)

![image](https://user-images.githubusercontent.com/1454332/104832115-fd89ae80-58d1-11eb-9946-4ec29f9ea8a9.png)

