### PR TITLE
update control-plane taints

### DIFF
--- a/roles/k8s/files/ingress/ingress-controller.yaml
+++ b/roles/k8s/files/ingress/ingress-controller.yaml
@@ -399,6 +399,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
+        # TODO: remove master toleration after k8s 1.24
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Equal
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Equal
@@ -628,6 +632,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
+        # TODO: remove master toleration after k8s 1.24
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Equal
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Equal
@@ -686,6 +694,10 @@ spec:
       nodeSelector:
         kubernetes.io/os: linux
       tolerations:
+        # TODO: remove master toleration after k8s 1.24
+        - key: node-role.kubernetes.io/master
+          effect: NoSchedule
+          operator: Equal
         - effect: NoSchedule
           key: node-role.kubernetes.io/control-plane
           operator: Equal

--- a/roles/k8s/files/monitoring/node-exporter.yaml
+++ b/roles/k8s/files/monitoring/node-exporter.yaml
@@ -50,7 +50,11 @@ spec:
               mountPath: /rootfs
       # these tolerations are need for deploying to master, ingress
       tolerations:
+      # TODO: remove master toleration after k8s 1.24
       - key: node-role.kubernetes.io/master
+        effect: NoSchedule
+        operator: Equal
+      - key: node-role.kubernetes.io/control-plane
         effect: NoSchedule
         operator: Equal
       - key: node-role.kubernetes.io/ingress

--- a/roles/k8s/files/setup/flannel.yaml
+++ b/roles/k8s/files/setup/flannel.yaml
@@ -163,6 +163,7 @@ spec:
       hostNetwork: true
       priorityClassName: system-node-critical
       tolerations:
+      # flannel is deployed to all nodes
       - operator: Exists
         effect: NoSchedule
       serviceAccountName: flannel

--- a/roles/kubeadm-control-plane/tasks/main.yml
+++ b/roles/kubeadm-control-plane/tasks/main.yml
@@ -1,6 +1,6 @@
 - name: start kubernetes control plane
   shell:
-    cmd: kubeadm init --control-plane-endpoint={{control_plane_ip}} --pod-network-cidr=10.244.0.0/16 --node-name=control-plane
+    cmd: kubeadm init --control-plane-endpoint={{control_plane_ip}} --pod-network-cidr=10.244.0.0/16 --node-name={{kubeadm_control_plane_node_name}}
   register: kubeadm_init_result
   failed_when:
   # get error
@@ -15,7 +15,6 @@
     line: "cgroupDriver: \"systemd\""
   become: True
 
-# TBD: daemon reload
 - name: enable kubelet service
   systemd:
     daemon_reload: True
@@ -23,5 +22,11 @@
     name: kubelet
   become: True
  
-# TBD: remove master taint
-#kubectl taint nodes control-plane node-role.kubernetes.io/master=:NoSchedule-
+- name: add control-plane taint
+  shell:
+    cmd: kubectl taint nodes {{kubeadm_control_plane_node_name}} node-role.kubernetes.io/control-plane=:NoSchedule
+
+# master taint will be removed after k8s 1.24
+- name: remove taint
+  shell:
+    cmd: kubectl taint nodes {{kubeadm_control_plane_node_name}} node-role.kubernetes.io/master=:NoSchedule-


### PR DESCRIPTION
## Why
<!-- Why we need this PR -->
- master taint will be removed after  k8s 1.24
- https://github.com/kubernetes/kubeadm/issues/2200

## What
<!-- What features are added in this PR -->
- add control-plane taint to control-plane node

## QA, Evidence
<!-- Things that support this PR is correct -->

```
k get nodes
NAME            STATUS   ROLES                  AGE   VERSION
control-plane   Ready    control-plane,master   27d   v1.21.3
worker-2        Ready    <none>                 4d    v1.21.3
worker-1         Ready    <none>                 27d   v1.21.3
```
